### PR TITLE
Do not ignore trex_interfaces if defined

### DIFF
--- a/roles/packet_gen/trex/trex_instance_config/templates/trex_cfg.yaml.j2
+++ b/roles/packet_gen/trex/trex_instance_config/templates/trex_cfg.yaml.j2
@@ -1,7 +1,11 @@
 #jinja2: lstrip_blocks: "true", trim_blocks: "false"
 - port_limit: {{ trex_port_info | length }}
   version: {{ trex_cfg_version | default(2) }}
+  {% if trex_interfaces is defined %}
+  interfaces: {{ trex_interfaces }}
+  {% else %}
   interfaces: {{ trex_full_nic_info | map(attribute='pci_slot') | list | sort | to_yaml }}
+  {% endif %}
   port_info:
   {% for port in trex_port_info %}
     - {{ port | to_nice_yaml | indent(6) }}


### PR DESCRIPTION
According to README:

Interfaces' PCI slots that will be used by Trex

 **Not** defined by default, can be discovered automatically or supplied by user.
```
trex_interfaces: ['00:03.0', '00:04.0'] # Trex interfaces PCI slots
```

However, before this fix trex_interfaces was ignored.