### PR TITLE
Add option to run Grout on DuT

### DIFF
--- a/playbooks/packet_gen/trex/performance_scenario.yml
+++ b/playbooks/packet_gen/trex/performance_scenario.yml
@@ -87,7 +87,15 @@
     - role: roles/packet_gen/trex/launch_testpmd
       vars:
         trex_host: "{{ trex_instances[ dut_group ] | default('trex') }}"
-      when: launch_testpmd | default(True)|bool
+      when:
+        - launch_testpmd | default(True)|bool
+        - not launch_grout | default(False)|bool
+
+- hosts: "{{ dut_group | default(omit) }}"
+  become: true
+  roles:
+    - role: roles/packet_gen/trex/launch_grout
+      when: launch_grout | default(False)|bool
 
 - hosts: "{{ trex_instances[ dut_group ] | default('trex') }}"
   become: true

--- a/roles/packet_gen/trex/README.md
+++ b/roles/packet_gen/trex/README.md
@@ -102,6 +102,13 @@ Launch TestPMD on DuT instance:
 launch_testpmd: True
 ```
 
+Launch Grout on DuT instance:
+
+`False` by default
+```
+launch_grout: False
+```
+
 Execute binary_search script on trex instance:
 
 `True` by default

--- a/roles/packet_gen/trex/bind_dpdk_nics/tasks/main.yml
+++ b/roles/packet_gen/trex/bind_dpdk_nics/tasks/main.yml
@@ -46,7 +46,7 @@
         state: mounted
 
     - name: Load Required Kernel Modules
-      modprobe:
+      community.general.modprobe:
         name: "{{ item['name'] }}"
         state: present
         params: "{{ item['params'] | default(omit) }}"
@@ -56,7 +56,7 @@
         - {'name': 'vfio-pci'}
 
     - name: Load Mellanox Kernel Modules when configured
-      modprobe:
+      community.general.modprobe:
         name: mlx5_core
         state: present
         persistent: "present"

--- a/roles/packet_gen/trex/launch_grout/defaults/main.yml
+++ b/roles/packet_gen/trex/launch_grout/defaults/main.yml
@@ -1,0 +1,3 @@
+grout_rpm: https://github.com/DPDK/grout/releases/download/edge/grout.x86_64.rpm
+grout_config: /etc/grout_config
+

--- a/roles/packet_gen/trex/launch_grout/tasks/main.yml
+++ b/roles/packet_gen/trex/launch_grout/tasks/main.yml
@@ -1,0 +1,20 @@
+- name: Ensure grout RPM is installed
+  ansible.builtin.dnf:
+    name: '{{ grout_rpm }}'
+    state: present
+    disable_gpg_check: true
+
+- name: Update grout.init
+  ansible.builtin.copy:
+    remote_src: yes
+    src: '{{ grout_config }}'
+    dest: /etc/grout.init
+    owner: root
+    group: root
+    mode: '0644'
+
+- name: Enable and start grout.service
+  ansible.builtin.systemd:
+    name: grout.service
+    enabled: true
+    state: restarted


### PR DESCRIPTION
This PR allows to use Grout[1] instead of Testpmd for forwarding packets back to T-rex.
The PR supposes that DuT VM is created with a desired Grout configuration in a file.
[1] https://github.com/DPDK/grout/