### PR TITLE
Support performance test with grout router

### DIFF
--- a/playbooks/packet_gen/trex/performance_scenario.yml
+++ b/playbooks/packet_gen/trex/performance_scenario.yml
@@ -87,7 +87,15 @@
     - role: roles/packet_gen/trex/launch_testpmd
       vars:
         trex_host: "{{ trex_instances[ dut_group ] | default('trex') }}"
-      when: launch_testpmd | default(True)|bool
+      when:
+        - launch_testpmd | default(True)|bool
+        - not launch_grout | default(False)|bool
+
+- hosts: "{{ dut_group | default(omit) }}"
+  become: true
+  roles:
+    - role: roles/packet_gen/trex/launch_grout
+      when: launch_grout | default(False)|bool
 
 - hosts: "{{ trex_instances[ dut_group ] | default('trex') }}"
   become: true

--- a/playbooks/packet_gen/trex/performance_scenario.yml
+++ b/playbooks/packet_gen/trex/performance_scenario.yml
@@ -76,6 +76,43 @@
         delay: 5
       when: osp_reboot | default(False)|bool
 
+- hosts: "{{ router_group | default(omit) }}"
+  become: true
+  roles:
+    - role: tuning/cpu_pinning_huge_pages
+      vars:
+        cpu_pinning_cores: "{{ router_lcores }}"
+        ssh_reboot: "{{ not osp_reboot | default(False)|bool }}"
+
+- hosts: localhost
+  gather_facts: False
+  tasks:
+    - block:
+        - name: get router vm name
+          set_fact:
+            router_vm: "{{ item.name }}"
+          when: "'router' in item['group']"
+          loop: "{{ dynamic_instances }}"
+
+        - name: Reboot router vm
+          openstack.cloud.server_action:
+            cloud: "{{ cloud_name | default('overcloud') }}"
+            action: reboot_soft
+            server: "{{ router_vm }}"
+            timeout: 300
+
+      when: osp_reboot | default(False)|bool
+
+- hosts: "{{ router_group | default(omit) }}"
+  gather_facts: False
+  become: true
+  tasks:
+    - name: Wait for server to restart successfully
+      wait_for_connection:
+        timeout: 300
+        delay: 5
+      when: osp_reboot | default(False)|bool
+
 - hosts: "{{ dut_group | default(omit) }}"
   roles:
     - role: roles/packet_gen/trex/bind_dpdk_nics
@@ -92,6 +129,20 @@
         - not launch_grout | default(False)|bool
 
 - hosts: "{{ dut_group | default(omit) }}"
+  become: true
+  roles:
+    - role: roles/packet_gen/trex/launch_grout
+      when: launch_grout | default(False)|bool
+
+- hosts: "{{ router_group | default(omit) }}"
+  roles:
+    - role: roles/packet_gen/trex/bind_dpdk_nics
+      vars:
+        discover_dut_macs: True
+        dpdk_binding_driver: 'vfio-pci'
+      when: launch_grout | default(False)|bool
+
+- hosts: "{{ router_group | default(omit) }}"
   become: true
   roles:
     - role: roles/packet_gen/trex/launch_grout

--- a/roles/packet_gen/trex/README.md
+++ b/roles/packet_gen/trex/README.md
@@ -102,6 +102,13 @@ Launch TestPMD on DuT instance:
 launch_testpmd: True
 ```
 
+Launch Grout on DuT instance:
+
+`False` by default
+```
+launch_grout: False
+```
+
 Execute binary_search script on trex instance:
 
 `True` by default

--- a/roles/packet_gen/trex/launch_grout/defaults/main.yml
+++ b/roles/packet_gen/trex/launch_grout/defaults/main.yml
@@ -1,0 +1,3 @@
+grout_rpm: https://github.com/DPDK/grout/releases/download/edge/grout.x86_64.rpm
+grout_config: /etc/grout_config
+

--- a/roles/packet_gen/trex/launch_grout/tasks/main.yml
+++ b/roles/packet_gen/trex/launch_grout/tasks/main.yml
@@ -1,0 +1,20 @@
+- name: Ensure grout RPM is installed
+  ansible.builtin.dnf:
+    name: '{{ grout_rpm }}'
+    state: present
+    disable_gpg_check: true
+
+- name: Update grout.init
+  ansible.builtin.copy:
+    remote_src: yes
+    src: '{{ grout_config }}'
+    dest: /etc/grout.init
+    owner: root
+    group: root
+    mode: '0644'
+
+- name: Enable and start grout.service
+  ansible.builtin.systemd:
+    name: grout.service
+    enabled: true
+    state: restarted


### PR DESCRIPTION
This PR allows to run performance test with an extra device that can have configuration (e.g. binding driver) other than DuT.