### PR TITLE
Fix parse PMD stats for multiqueue

### DIFF
--- a/playbooks/tripleo/multiqueue/multiqueue_learning.yml
+++ b/playbooks/tripleo/multiqueue/multiqueue_learning.yml
@@ -164,9 +164,9 @@
       loop: "{{ testpmd_down_interfaces | default([]) }}"
 
 - hosts: trex
-  become: true
   pre_tasks:
     - name: save pmd_rxq_show_output to file
+      become: true
       copy:
         content: "{{ hostvars[dut_compute]['pmd_rxq_show_cmd_output'] }}"
         dest: "{{ pmd_rxq_show_output }}"


### PR DESCRIPTION
Before the fix we got this error:
```
"stderr_lines": [
    "Traceback (most recent call last):",
    "  File \"/opt/bench-trafficgen/trafficgen//multiqueue.py\", line 486, in <module>",
    "    main()",
    "  File \"/opt/bench-trafficgen/trafficgen//multiqueue.py\", line 458, in main",
    "    with open(args.traffic_json, 'w') as f:",
    "PermissionError: [Errno 13] Permission denied: '/tmp/queues.json'"
],
```

The reason is that calling the `roles/packet_gen/trex/multiqueue` role from the multiqueue learning playbook and action `parse_pmd_stats` the task was run with become set to true and the `/tmp/queues.json` owner is cloud-user. In order to avoid this error, become true is removed when action is `parse_pmd_stats` because root not needed for this action.