### PR TITLE
binary_search: skip Stop TestPMD when DUT is not in inventory

### DIFF
--- a/roles/packet_gen/trex/binary_search/tasks/main.yml
+++ b/roles/packet_gen/trex/binary_search/tasks/main.yml
@@ -180,8 +180,11 @@
 - name: Stop TestPMD On DuT
   shell: "tmux list-sessions -F '#S' | xargs -n1 tmux kill-session -t"
   become: True
-  delegate_to: "{{ groups[dut_group]|first }}"
-  when: "dut_group and dut_group|length > 0"
+  delegate_to: "{{ groups[dut_group] | first }}"
+  when:
+    - dut_group and dut_group | length > 0
+    - launch_testpmd | default(true) | bool
+    - groups[dut_group] | default([]) | length > 0
 
 - name: Parse JSON Result From Output File
   block:


### PR DESCRIPTION
## Problem

The `Stop TestPMD On DuT` task in `binary_search/tasks/main.yml` unconditionally
delegates to `groups[dut_group]|first`, which raises a fatal error:

```
No first item, sequence was empty.
```

when `dut_group` is a valid Ansible group name but the group contains no hosts.

## When does this happen?

When the DUT is an **OpenShift pod** rather than a VM, the caller:

1. Passes `launch_testpmd=false` (testpmd is already running inside the pod, started
   by the pod's entrypoint — ansible-nfv does not need to manage its lifecycle).
2. Has an empty `[sriov_dut]` / `[dpdk_dut]` group in the inventory (no SSH-reachable
   host to delegate to).

The existing `when: "dut_group and dut_group|length > 0"` only checks that the
variable is non-empty, not that the group actually has hosts.

## Fix

Add two additional guards to the `when` condition:

- **`launch_testpmd | default(true) | bool`**: if the caller did not ask
  ansible-nfv to launch testpmd (`launch_testpmd=false`), there is nothing to
  stop — skip the task.
- **`groups[dut_group] | default([]) | length > 0`**: if the group has no hosts,
  skip the delegation rather than failing with an empty-sequence error.

## Testing

Verified with a ShiftStack (OpenShift on OpenStack) NFV setup where the testpmd
DUT runs as an SR-IOV pod. With `launch_testpmd=false` and an empty `sriov_dut`
inventory group, the binary search completes successfully and the stop step is
correctly skipped.