### PR TITLE
performance_scenario: fix default(omit) in play-level hosts field

### DIFF
--- a/playbooks/packet_gen/trex/performance_scenario.yml
+++ b/playbooks/packet_gen/trex/performance_scenario.yml
@@ -16,12 +16,12 @@
         name: roles/post_install/dynamic_host_inventory
       loop: "{{ dynamic_instances }}"
 
-- hosts: "{{ dut_compute | default(omit) }}"
+- hosts: "{{ dut_compute | default([]) or [] }}"
   become: true
   roles:
     - role: roles/packet_gen/trex/compute_tuning
 
-- hosts: "{{ hci_group | default(omit) }}"
+- hosts: "{{ hci_group | default([]) or [] }}"
   roles:
     - role: roles/packet_gen/trex/launch_fio
       when: launch_hci_stress | default(False)|bool
@@ -31,7 +31,7 @@
     - role: roles/packet_gen/trex/trex_instance_config
       when: trex_instance_config | default(True)|bool
 
-- hosts: "{{ dut_group | default(omit) }}"
+- hosts: "{{ dut_group | default([]) or [] }}"
   become: true
   roles:
     - role: tuning/cpu_pinning_huge_pages
@@ -66,7 +66,7 @@
             #openstack server reboot --wait "{{ testpmd_vm }}"
       when: osp_reboot | default(False)|bool
 
-- hosts: "{{ dut_group | default(omit) }}"
+- hosts: "{{ dut_group | default([]) or [] }}"
   gather_facts: False
   become: true
   tasks:
@@ -76,7 +76,7 @@
         delay: 5
       when: osp_reboot | default(False)|bool
 
-- hosts: "{{ dut_group | default(omit) }}"
+- hosts: "{{ dut_group | default([]) or [] }}"
   roles:
     - role: roles/packet_gen/trex/bind_dpdk_nics
       vars:
@@ -91,7 +91,7 @@
         - launch_testpmd | default(True)|bool
         - not launch_grout | default(False)|bool
 
-- hosts: "{{ dut_group | default(omit) }}"
+- hosts: "{{ dut_group | default([]) or [] }}"
   become: true
   roles:
     - role: roles/packet_gen/trex/launch_grout
@@ -133,7 +133,7 @@
         delay: 5
       when: osp_reboot | default(False)|bool
 
-- hosts: "{{ dut_compute | default(omit) }}"
+- hosts: "{{ dut_compute | default([]) or [] }}"
   become: true
   roles:
     - role: roles/packet_gen/trex/multiqueue_autob_config
@@ -154,7 +154,7 @@
     - role: roles/packet_gen/trex/binary_search
       when: binary_search | default(True)|bool
 
-- hosts: "{{ dut_compute | default(omit) }}"
+- hosts: "{{ dut_compute | default([]) or [] }}"
   become: true
   roles:
     - role: roles/packet_gen/trex/multiqueue_autob_config


### PR DESCRIPTION
## Problem

Several plays in \`performance_scenario.yml\` use \`default(omit)\` in the \`hosts:\` field:

\`\`\`yaml
- hosts: "{{ dut_compute | default(omit) }}"
\`\`\`

The \`default(omit)\` filter is designed exclusively for **module arguments**. When used
in a play-level \`hosts:\` field, it does not skip the play. Instead, it evaluates to
an empty string when the variable is undefined, causing Ansible to fail with:

\`\`\`
ERROR! the field 'hosts' is required, and cannot have empty values
\`\`\`

This makes the playbook completely unusable when \`dut_compute\` is not set (e.g.,
when the DUT is a Kubernetes pod rather than a VM).

## Fix

Replace all \`default(omit)\` in \`hosts:\` position with \`default([]) or []\`:

| Variable state | Result | Effect |
|---|---|---|
| undefined | \`default([])\` → \`[]\`, \`[] or []\` → \`[]\` | Play skips |
| empty string \`""\` | \`"" or []\` → \`[]\` | Play skips |
| set to \`"compute-0"\` | \`"compute-0" or []\` → \`"compute-0"\` | Play runs normally |

An empty host list (\`hosts: []\`) causes Ansible to skip the play with
"skipping: no hosts matched" — the correct behaviour when the feature
is not configured.

## Affected plays

- \`dut_compute\`: \`compute_tuning\` and \`multiqueue_autob_config\` roles
- \`hci_group\`: \`launch_fio\` role
- \`dut_group\`: \`cpu_pinning_huge_pages\`, \`bind_dpdk_nics\`, \`launch_testpmd\`, \`launch_grout\` roles

## Testing

Verified with a ShiftStack (OpenShift on OpenStack) NFV setup where:
- \`dut_compute\` is not set (DUT runs as an SR-IOV pod, not a VM)
- \`hci_group\` is not set
- All affected plays are correctly skipped without error